### PR TITLE
Colorized the terminal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.google.pdsl</groupId>
     <artifactId>pdsl</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
 
     <name>pdsl</name>
     <url>http://www.github.com/google/polymorphicDSL</url>
@@ -139,10 +139,10 @@
                         <artifactId>antlr4-maven-plugin</artifactId>
                         <version>${antlr.version}</version>
                         <configuration>
-<!--
+														<!--
                             <sourceDirectory>${basedir}/src/test/antlr4</sourceDirectory>
                             <libDirectory>${basedir}/src/test/antlr4/com/pdsl/grammars</libDirectory>
--->
+														-->
                             <sourceDirectory>${basedir}/src/main/antlr4</sourceDirectory>
 														<preparationGoals>antlr4</preparationGoals>
                         </configuration>

--- a/src/main/java/com/pdsl/executors/DefaultPolymorphicDslTestExecutor.java
+++ b/src/main/java/com/pdsl/executors/DefaultPolymorphicDslTestExecutor.java
@@ -1,5 +1,6 @@
 package com.pdsl.executors;
 
+import com.pdsl.logging.AnsiTerminalColorHelper;
 import com.pdsl.logging.PdslThreadSafeOutputStream;
 import com.pdsl.reports.DefaultTestResult;
 import com.pdsl.reports.MetadataTestRunResults;
@@ -30,24 +31,24 @@ public class DefaultPolymorphicDslTestExecutor implements TraceableTestRunExecut
     @Override
     public PolymorphicDslTestRunResults runTests(Collection<TestCase> testCases, ParseTreeListener phraseRegistry) {
         // Walk the phrase registry to make sure all phrases are defined
-        logger.info("Running tests...");
+        logger.info(AnsiTerminalColorHelper.BRIGHT_YELLOW + "Running tests..." + AnsiTerminalColorHelper.RESET);
         MetadataTestRunResults results = walk(testCases, new PhraseRegistry(phraseRegistry), "NONE");
         if (results.failingTestTotal() == 0) {
-            logger.info("All phrases successfully executed!");
+            logger.info(AnsiTerminalColorHelper.BRIGHT_GREEN + "All phrases successfully executed!" + AnsiTerminalColorHelper.RESET);
         } else {
-            logger.error("There were test failures!");
+            logger.error(AnsiTerminalColorHelper.BRIGHT_RED + "There were test failures!" + AnsiTerminalColorHelper.RESET);
         }
         return (PolymorphicDslTestRunResults) results;
     }
 
     @Override
     public TestRunResults runTests(Collection<TestCase> testCases, ParseTreeVisitor subgrammarVisitor) {
-        logger.info("Running tests...");
+        logger.info(AnsiTerminalColorHelper.BRIGHT_YELLOW + "Running tests..." + AnsiTerminalColorHelper.RESET);
         MetadataTestRunResults results = walk(testCases, new PhraseRegistry(subgrammarVisitor), "NONE");
         if (results.failingTestTotal() == 0) {
-            logger.info("All phrases successfully executed!");
+            logger.info(AnsiTerminalColorHelper.BRIGHT_YELLOW + "All phrases successfully executed!" + AnsiTerminalColorHelper.RESET);
         } else {
-            logger.error("There were test failures!");
+            logger.error(AnsiTerminalColorHelper.BRIGHT_RED + "There were test failures!" + AnsiTerminalColorHelper.RESET);
         }
         return (PolymorphicDslTestRunResults) results;
     }
@@ -87,20 +88,23 @@ public class DefaultPolymorphicDslTestExecutor implements TraceableTestRunExecut
                     while (testBody.hasNext()) {
                         TestSection section = testBody.next();
                         if (section.getMetaData().isPresent()) {
+                            notifyStreams(AnsiTerminalColorHelper.CYAN.getBytes(charset));
                             notifyStreams(section.getMetaData().get());
+                            notifyStreams(AnsiTerminalColorHelper.RESET.getBytes(charset));
                         }
                         activePhrase = section.getPhrase();
-                        notifyStreams((activePhrase.getParseTree().getText() + "\n").getBytes(charset));
                         if (phraseRegistry.listener.isPresent()) {
                             walker.walk(phraseRegistry.listener.get(), activePhrase.getParseTree());
                         } else {
                             phraseRegistry.visitor.get().visit(activePhrase.getParseTree());
                         }
                         phraseIndex++;
+                        notifyStreams((AnsiTerminalColorHelper.GREEN + activePhrase.getParseTree().getText() + "\n" + AnsiTerminalColorHelper.RESET).getBytes(charset));
                     }
                     results.addTestResult(DefaultTestResult.passingTest(testCase));
                 }
             } catch (Throwable e) {
+                notifyStreams((AnsiTerminalColorHelper.BRIGHT_RED + activePhrase.getParseTree().getText() + "\n" + AnsiTerminalColorHelper.RESET).getBytes(charset));
                 int phrasesSkippedDueToFailure = 0;
                 while (testBody.hasNext()) {
                     testBody.next();
@@ -139,9 +143,9 @@ public class DefaultPolymorphicDslTestExecutor implements TraceableTestRunExecut
         logger.info("Running tests...");
         MetadataTestRunResults results = walk(testCases, new PhraseRegistry(subgrammarListener), context);
         if (results.failingTestTotal() == 0) {
-            logger.info("All phrases successfully executed!");
+            logger.info(AnsiTerminalColorHelper.BRIGHT_GREEN + "All phrases successfully executed!" + AnsiTerminalColorHelper.RESET);
         } else {
-            logger.error("There were test failures!");
+            logger.error(AnsiTerminalColorHelper.BRIGHT_RED + "There were test failures!" + AnsiTerminalColorHelper.RESET);
         }
         return (PolymorphicDslTestRunResults) results;
     }
@@ -151,9 +155,9 @@ public class DefaultPolymorphicDslTestExecutor implements TraceableTestRunExecut
         logger.info("Running tests...");
         MetadataTestRunResults results = walk(testCases, new PhraseRegistry(visitor), context);
         if (results.failingTestTotal() == 0) {
-            logger.info("All phrases successfully executed!");
+            logger.info(AnsiTerminalColorHelper.BRIGHT_GREEN + "All phrases successfully executed!" + AnsiTerminalColorHelper.RESET);
         } else {
-            logger.error("There were test failures!");
+            logger.error(AnsiTerminalColorHelper.BRIGHT_RED + "There were test failures!" + AnsiTerminalColorHelper.RESET);
         }
         return (PolymorphicDslTestRunResults) results;
     }

--- a/src/main/java/com/pdsl/logging/AnsiTerminalColorHelper.java
+++ b/src/main/java/com/pdsl/logging/AnsiTerminalColorHelper.java
@@ -4,45 +4,45 @@ package com.pdsl.logging;
 public class AnsiTerminalColorHelper {
 
 		private AnsiTerminalColorHelper() {}
+    private static final char ESCAPE_CHAR = 27;
+    public static final String RESET = ESCAPE_CHAR + "\u001B[0m";
+    public static final String BLACK = ESCAPE_CHAR + "\u001B[30m";
+    public static final String RED = ESCAPE_CHAR + "\u001B[31m";
+    public static final String GREEN = ESCAPE_CHAR + "\u001B[32m";
+    public static final String YELLOW = ESCAPE_CHAR + "\u001B[33m";
+    public static final String BLUE = ESCAPE_CHAR + "\u001B[34m";
+    public static final String PURPLE = ESCAPE_CHAR + "\u001B[35m";
+    public static final String CYAN = ESCAPE_CHAR + "\u001B[36m";
+    public static final String WHITE = ESCAPE_CHAR + "\u001B[37m";
 
-    public static final String RESET = "\u001B[0m";
-    public static final String BLACK = "\u001B[30m";
-    public static final String RED = "\u001B[31m";
-    public static final String GREEN = "\u001B[32m";
-    public static final String YELLOW = "\u001B[33m";
-    public static final String BLUE = "\u001B[34m";
-    public static final String PURPLE = "\u001B[35m";
-    public static final String CYAN = "\u001B[36m";
-    public static final String WHITE = "\u001B[37m";
-
-    public static final String BRIGHT_BLACK = "\u001B[90m";
-    public static final String BRIGHT_RED = "\u001B[91m";
-    public static final String BRIGHT_GREEN = "\u001B[92m";
-    public static final String BRIGHT_YELLOW = "\u001B[93m";
-    public static final String BRIGHT_BLUE = "\u001B[94m";
-    public static final String BRIGHT_PURPLE = "\u001B[95m";
-    public static final String BRIGHT_CYAN = "\u001B[96m";
-    public static final String BRIGHT_WHITE = "\u001B[97m";
+    public static final String BRIGHT_BLACK = ESCAPE_CHAR + "\u001B[90m";
+    public static final String BRIGHT_RED = ESCAPE_CHAR +"\u001B[91m";
+    public static final String BRIGHT_GREEN = ESCAPE_CHAR + "\u001B[92m";
+    public static final String BRIGHT_YELLOW = ESCAPE_CHAR + "\u001B[93m";
+    public static final String BRIGHT_BLUE = ESCAPE_CHAR + "\u001B[94m";
+    public static final String BRIGHT_PURPLE = ESCAPE_CHAR + "\u001B[95m";
+    public static final String BRIGHT_CYAN = ESCAPE_CHAR + "\u001B[96m";
+    public static final String BRIGHT_WHITE = ESCAPE_CHAR + "\u001B[97m";
 
 
-    public static final String BG_BLACK = "\u001B[40m";
-    public static final String BG_RED = "\u001B[41m";
-    public static final String BG_GREEN = "\u001B[42m";
-    public static final String BG_YELLOW = "\u001B[43m";
-    public static final String BG_BLUE = "\u001B[44m";
-    public static final String BG_PURPLE = "\u001B[45m";
-    public static final String BG_CYAN = "\u001B[46m";
-    public static final String BG_WHITE = "\u001B[47m";
+    public static final String BG_BLACK = ESCAPE_CHAR + "\u001B[40m";
+    public static final String BG_RED = ESCAPE_CHAR + "\u001B[41m";
+    public static final String BG_GREEN = ESCAPE_CHAR + "\u001B[42m";
+    public static final String BG_YELLOW = ESCAPE_CHAR + "\u001B[43m";
+    public static final String BG_BLUE = ESCAPE_CHAR + "\u001B[44m";
+    public static final String BG_PURPLE = ESCAPE_CHAR + "\u001B[45m";
+    public static final String BG_CYAN = ESCAPE_CHAR + "\u001B[46m";
+    public static final String BG_WHITE = ESCAPE_CHAR + "\u001B[47m";
 
-    public static final String BG_BRIGHT_BLACK = "\u001B[100m";
-    public static final String BG_BRIGHT_RED = "\u001B[101m";
-    public static final String BG_BRIGHT_GREEN = "\u001B[102m";
-    public static final String BG_BRIGHT_YELLOW = "\u001B[103m";
-    public static final String BG_BRIGHT_BLUE = "\u001B[104m";
-    public static final String BG_BRIGHT_PURPLE = "\u001B[105m";
-    public static final String BG_BRIGHT_CYAN = "\u001B[106m";
-    public static final String BG_BRIGHT_WHITE = "\u001B[107m";
+    public static final String BG_BRIGHT_BLACK = ESCAPE_CHAR + "\u001B[100m";
+    public static final String BG_BRIGHT_RED = ESCAPE_CHAR + "\u001B[101m";
+    public static final String BG_BRIGHT_GREEN = ESCAPE_CHAR + "\u001B[102m";
+    public static final String BG_BRIGHT_YELLOW = ESCAPE_CHAR + "\u001B[103m";
+    public static final String BG_BRIGHT_BLUE = ESCAPE_CHAR + "\u001B[104m";
+    public static final String BG_BRIGHT_PURPLE = ESCAPE_CHAR + "\u001B[105m";
+    public static final String BG_BRIGHT_CYAN = ESCAPE_CHAR + "\u001B[106m";
+    public static final String BG_BRIGHT_WHITE = ESCAPE_CHAR +"\u001B[107m";
 
-    public static final String BOLD = "\033[1m";
-    public static final String FORMAT_STRIKETHROUGH = "\u001b[9m";
+    public static final String BOLD = ESCAPE_CHAR + "\033[1m";
+    public static final String FORMAT_STRIKETHROUGH = ESCAPE_CHAR + "\u001b[9m";
 }


### PR DESCRIPTION
Colors have so far only worked in IDEs like intellij, but failed on Unix terminals. This appears to have been due to the absence of character \033.