### PR TITLE
Removing HTML Unit as it causes a security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,13 +86,6 @@
         </dependency>
 
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
-            <artifactId>htmlunit</artifactId>
-            <version>2.52.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>3.23.4</version>


### PR DESCRIPTION
Code scans indicate HTML unit has major security vulnerabilities. It doesn't seem like an alternative version is available, so we're deprecating this library and associated tests.