### PR TITLE
Refactor InterpreterObj, add parallelism properties to JUnit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@
                     <version>${antlr.version}</version>
                     <configuration>
                         <arguments>
-                            <argumenent>-visitor</argumenent>
+                            <argument>-visitor</argument>
                         </arguments>
                     </configuration>
                     <executions>

--- a/src/main/java/com/pdsl/executors/DefaultPolymorphicDslTestExecutor.java
+++ b/src/main/java/com/pdsl/executors/DefaultPolymorphicDslTestExecutor.java
@@ -159,7 +159,7 @@ public class DefaultPolymorphicDslTestExecutor implements TraceableTestRunExecut
     public MetadataTestRunResults runTestsWithMetadata(Collection<TestCase> testCases,
                                                        ParseTreeListener subgrammarListener, String context) {
         notifyBeforeTestSuite(testCases, subgrammarListener, context);
-        MetadataTestRunResults results = walk(testCases, new InterpreterObj(subgrammarListener),
+        MetadataTestRunResults results = walk(testCases, InterpreterObj.ofListener(() -> subgrammarListener),
                 context);
         notifyAfterTestSuite(testCases, subgrammarListener, results, context);
         return results;

--- a/src/main/java/com/pdsl/executors/InterpreterObj.java
+++ b/src/main/java/com/pdsl/executors/InterpreterObj.java
@@ -115,8 +115,6 @@ public final class InterpreterObj {
    * <p>
    * This will use the supplied start rule.
    * The supplied parseTreeListener will be used as a singleton.
-   *
-   * @return InterpreterObj
    */
   public InterpreterObj(ParseTreeVisitor<?> parseTreeVisitor, String startRule) {
     this.parseTreeVisitor = Optional.of(() -> parseTreeVisitor);

--- a/src/main/java/com/pdsl/executors/InterpreterObj.java
+++ b/src/main/java/com/pdsl/executors/InterpreterObj.java
@@ -2,7 +2,7 @@ package com.pdsl.executors;
 
 import java.util.Optional;
 import java.util.function.Supplier;
-import com.pdsl.runners.PdslTestParams;
+
 import org.antlr.v4.runtime.tree.ParseTreeListener;
 import org.antlr.v4.runtime.tree.ParseTreeVisitor;
 
@@ -15,24 +15,36 @@ public final class InterpreterObj {
 
   private final Optional<Supplier<ParseTreeVisitor<?>>> parseTreeVisitor;
   private final Optional<Supplier<ParseTreeListener>> parseTreeListener;
-  private final String startRule;
+  private final Optional<String> startRule;
 
   public InterpreterObj(ParseTreeVisitor<?> parseTreeVisitor) {
     this.parseTreeVisitor = Optional.of(() -> parseTreeVisitor);
     this.parseTreeListener = Optional.empty();
-    this.startRule = PdslTestParams.DEFAULT_ALL_RULE;
+    this.startRule = Optional.empty();
+  }
+
+  /**
+   * Creates a InterpreterObj from the supplied parameter.
+   * <p>
+   * This will use the default start rule.
+   * The supplied parseTreeListener will be used as a singleton.
+   */
+  public InterpreterObj(ParseTreeListener parseTreeListener) {
+    this.parseTreeVisitor = Optional.empty();
+    this.parseTreeListener = Optional.of(() -> parseTreeListener);
+    this.startRule = Optional.empty();
   }
 
   /**
    * Creates a InterpreterObj from the supplied parameters.
-   *
+   * <p>
    * This will use the default start rule. If a specific start rule is needed use the related
    * method ofVisitor(supplier, String)}
    *
    * @return InterpreterObj
    */
   public static InterpreterObj ofVisitor(Supplier<ParseTreeVisitor<?>> supplier) {
-    return new InterpreterObj(supplier, PdslTestParams.DEFAULT_ALL_RULE);
+    return new InterpreterObj(supplier);
   }
 
   /**
@@ -49,8 +61,8 @@ public final class InterpreterObj {
    *
    * @return InterpreterObj
    */
-  public static InterpreterObj ofListener(Supplier<ParseTreeListener> supplier, String startRule) {
-    return new InterpreterObj(startRule, supplier);
+  public static InterpreterObj ofListener(Supplier<ParseTreeListener> listenerSupplier, String startRule) {
+    return new InterpreterObj(listenerSupplier, Optional.ofNullable(startRule));
   }
 
   /**
@@ -61,36 +73,29 @@ public final class InterpreterObj {
    *
    * @return InterpreterObj
    */
-  public static InterpreterObj ofListener(Supplier<ParseTreeListener> supplier) {
-    return new InterpreterObj(PdslTestParams.DEFAULT_ALL_RULE, supplier);
+  public static InterpreterObj ofListener(Supplier<ParseTreeListener> listenerSupplier) {
+    return new InterpreterObj(listenerSupplier, Optional.empty());
+  }
+
+  // Deal with type erasure by shuffling parameter order for listeners and visitors
+  private InterpreterObj(Supplier<ParseTreeVisitor<?>> parseTreeVisitorSupplier) {
+    this.parseTreeVisitor = Optional.of(parseTreeVisitorSupplier);
+    this.parseTreeListener = Optional.empty();
+    this.startRule = Optional.empty();
   }
 
   // Deal with type erasure by shuffling parameter order for listeners and visitors
   private InterpreterObj(Supplier<ParseTreeVisitor<?>> parseTreeVisitorSupplier, String startRule) {
     this.parseTreeVisitor = Optional.of(parseTreeVisitorSupplier);
     this.parseTreeListener = Optional.empty();
-    this.startRule = startRule;
+    this.startRule = Optional.of(startRule);
   }
+
   // Deal with type erasure by shuffling parameter order for listeners and visitors
-  private InterpreterObj(String startRule, Supplier<ParseTreeListener> parseTreeListenerSupplier) {
+  private InterpreterObj(Supplier<ParseTreeListener> parseTreeListenerSupplier, Optional<String> startRule) {
     this.parseTreeVisitor = Optional.empty();
     this.parseTreeListener = Optional.of(parseTreeListenerSupplier);
-    this.startRule = PdslTestParams.DEFAULT_ALL_RULE;
-  }
-
-
-  /**
-   * Creates a InterpreterObj from the supplied parameter.
-   *
-   * This will use the default start rule.
-   * The supplied parseTreeListener will be used as a singleton.
-   *
-   * @return InterpreterObj
-   */
-  public InterpreterObj(ParseTreeListener parseTreeListener) {
-    this.parseTreeVisitor = Optional.empty();
-    this.parseTreeListener = Optional.of(() -> parseTreeListener);
-    this.startRule = PdslTestParams.DEFAULT_ALL_RULE;
+    this.startRule = startRule;
   }
 
   /**
@@ -98,18 +103,16 @@ public final class InterpreterObj {
    *
    * This will use the supplied start rule.
    * The supplied parseTreeListener will be used as a singleton.
-   *
-   * @return InterpreterObj
    */
-  public InterpreterObj(ParseTreeListener parseTreeListener, String startRule) {
+  private InterpreterObj(ParseTreeListener parseTreeListener, String startRule) {
     this.parseTreeVisitor = Optional.empty();
     this.parseTreeListener = Optional.of(() -> parseTreeListener);
-    this.startRule = startRule;
+    this.startRule = Optional.of(startRule);
   }
 
   /**
    * Creates a InterpreterObj from the supplied parameter.
-   *
+   * <p>
    * This will use the supplied start rule.
    * The supplied parseTreeListener will be used as a singleton.
    *
@@ -118,7 +121,7 @@ public final class InterpreterObj {
   public InterpreterObj(ParseTreeVisitor<?> parseTreeVisitor, String startRule) {
     this.parseTreeVisitor = Optional.of(() -> parseTreeVisitor);
     this.parseTreeListener = Optional.empty();
-    this.startRule = startRule;
+    this.startRule = Optional.of(startRule);
   }
 
   public Optional<ParseTreeVisitor<?>> getParseTreeVisitor() {
@@ -129,7 +132,7 @@ public final class InterpreterObj {
     return parseTreeListener.map(Supplier::get);
   }
   
-  public String getStartRule(){
+  public Optional<String> getStartRule(){
     return this.startRule;
   }
 

--- a/src/main/java/com/pdsl/gherkin/PickleJarFactory.java
+++ b/src/main/java/com/pdsl/gherkin/PickleJarFactory.java
@@ -6,7 +6,6 @@ import com.pdsl.gherkin.models.GherkinRule;
 import com.pdsl.gherkin.models.GherkinScenario;
 import com.pdsl.gherkin.models.GherkinStep;
 import com.pdsl.gherkin.models.GherkinString;
-import com.pdsl.reports.TestResult;
 import com.pdsl.transformers.PolymorphicDslFileException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -14,6 +13,7 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -23,24 +23,42 @@ import java.util.stream.Collectors;
  */
 public class PickleJarFactory implements GherkinObservable {
 
-    public static final PickleJarFactory DEFAULT = new PickleJarFactory(new PdslGherkinInterpreterImpl(), new PdslGherkinListenerImpl(), StandardCharsets.UTF_8);
+    public static final PickleJarFactory DEFAULT = new PickleJarFactory(
+            new PdslGherkinInterpreterImpl(),
+            PdslGherkinListenerImpl::new,
+            StandardCharsets.UTF_8
+    );
     private final Charset charset;
     private final PdslGherkinRecognizer pdslGherkinRecognizer;
-    private final PdslGherkinListener listener;
+    private final Supplier<PdslGherkinListener> listenerSupplier;
     private List<GherkinObserver> observers = new ArrayList<>();
 
     public static PickleJarFactory getDefaultPickleJarFactory(){
-        return new PickleJarFactory(new PdslGherkinInterpreterImpl(), new PdslGherkinListenerImpl(), StandardCharsets.UTF_8);
+        return new PickleJarFactory(new PdslGherkinInterpreterImpl(), PdslGherkinListenerImpl::new, StandardCharsets.UTF_8);
     }
 
     public PickleJarFactory(PdslGherkinRecognizer pdslGherkinRecognizer, PdslGherkinListener gherkinListener, Charset charset) {
         this.pdslGherkinRecognizer = pdslGherkinRecognizer;
-        this.listener = gherkinListener;
+        this.listenerSupplier = () -> gherkinListener;
         this.charset = charset;
     }
+
+    public PickleJarFactory(PdslGherkinRecognizer pdslGherkinRecognizer, Supplier<PdslGherkinListener> listenerSupplier, Charset charset) {
+        this.pdslGherkinRecognizer = pdslGherkinRecognizer;
+        this.listenerSupplier = listenerSupplier;
+        this.charset = charset;
+    }
+
     public PickleJarFactory(PdslGherkinRecognizer pdslGherkinRecognizer, PdslGherkinListener gherkinListener, Charset charset, List<GherkinObserver> observers) {
         this.pdslGherkinRecognizer = pdslGherkinRecognizer;
-        this.listener = gherkinListener;
+        this.listenerSupplier = () -> gherkinListener;
+        this.charset = charset;
+        this.observers = observers;
+    }
+
+    public PickleJarFactory(PdslGherkinRecognizer pdslGherkinRecognizer, Supplier<PdslGherkinListener> listenerSupplier, Charset charset, List<GherkinObserver> observers) {
+        this.pdslGherkinRecognizer = pdslGherkinRecognizer;
+        this.listenerSupplier = listenerSupplier;
         this.charset = charset;
         this.observers = observers;
     }
@@ -49,7 +67,7 @@ public class PickleJarFactory implements GherkinObservable {
     /**
      * Converts a list of feature files into a list of {@code PickleJar}.
      * <p>
-     * The primary purpose of this is to both  read all of the feature files (and making sure they exist) and
+     * The primary purpose of this is to both read all the feature files (and making sure they exist) and
      * parameter substitutions on the text if needed
      *
      * @param testResources List of URIs to feature files
@@ -60,7 +78,7 @@ public class PickleJarFactory implements GherkinObservable {
         // Parse each gherkin file
         try {
             for (URI uri : testResources) {
-                features.add(pdslGherkinRecognizer.interpretGherkinFileStrictly(uri, listener));
+                features.add(pdslGherkinRecognizer.interpretGherkinFileStrictly(uri, listenerSupplier.get()));
             }
         } catch (IOException e) {
             throw new PolymorphicDslFileException("Could not open file!", e);
@@ -250,37 +268,35 @@ public class PickleJarFactory implements GherkinObservable {
             for (int i = 0; i < rawTag.length(); i++) {
                 char c = rawTag.charAt(i);
                 switch (c) {
-                    case ' ': /* fall through */
-                    case '\t': /* fall through */
-                    case '\n': /* fall through */
+                    case ' ', '\t', '\r', '\n' -> {
+                        /* fall through */
                         if (buildingTag) { // We encountered an @ earlier, otherwise we're skipping whitespace at the start of a string
                             tags.add(tagBuilder.toString(charset));
                             tagBuilder.reset();
                             buildingTag = false;
                         }
-                        break;
-                    case '#':
-                        if (!buildingTag) { // Comment at end of raw tag. Ignore the rest
-                            return tags;
-                        }
-                        tagBuilder.write(c);
-                        break;
-                    case '@':
+                        continue;
+                    }
+
+                    case '@' -> {
                         if (buildingTag) { //Joined tag (e.g, @tagOne@tagTwo
                             tags.add(tagBuilder.toString(charset));
                             tagBuilder.reset();
                         }
                         buildingTag = true;
-                        /* fall through */
-                    default:
-                        if (buildingTag) {
-                            tagBuilder.write(c);
-                        } else {
+                    }
+                    case '#' -> {
+                        if (!buildingTag) { // Comment at end of raw tag. Ignore the rest
+                            return tags;
+                        }
+                    }
+                    default -> {
+                        if (!buildingTag) {
                             throw new IllegalArgumentException("Illegal tags. Got confused by " + rawTag);
                         }
-                        buildingTag = true;
-                        break;
+                    }
                 }
+                tagBuilder.write(c);
             }
         }
         String remainingTag = tagBuilder.toString(charset);

--- a/src/main/java/com/pdsl/runners/SharedTestSuiteVisitor.java
+++ b/src/main/java/com/pdsl/runners/SharedTestSuiteVisitor.java
@@ -87,7 +87,7 @@ public class SharedTestSuiteVisitor implements RecognizerParams.RecognizerParams
         TestResourceFinder finder = finderGenerator.get(includes,excludes);
         Set<URI> testResources = new HashSet<>();
         // Find the files we will be testing
-        Optional<Collection<URI>> resources =  finder.scanForTestResources(resourceRoot);
+        Optional<Collection<URI>> resources = finder.scanForTestResources(resourceRoot);
         resources.ifPresent(testResources::addAll);
         if (testResources.isEmpty()) {
             throw new IllegalArgumentException(String.format(

--- a/src/main/java/com/pdsl/specifications/FileSystemTestResourceFinder.java
+++ b/src/main/java/com/pdsl/specifications/FileSystemTestResourceFinder.java
@@ -5,7 +5,6 @@ import com.pdsl.transformers.PolymorphicDslFileException;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
@@ -94,7 +93,7 @@ public class FileSystemTestResourceFinder implements TestResourceFinder {
             Collection<Path> matches = findMatchingFiles(sourceDirectory, pathMatcher);
             Collection<URI> resources = matches.stream()
                     .map(Path::toUri)
-                    .collect(Collectors.toList());
+                    .toList();
             return resources.isEmpty() ? Optional.empty() : Optional.of(resources);
         } catch (IOException e) {
             throw new PolymorphicDslFileException("Error searching for test resources!", e);

--- a/src/main/java/com/pdsl/specifications/FileSystemTestResourceGenerator.java
+++ b/src/main/java/com/pdsl/specifications/FileSystemTestResourceGenerator.java
@@ -35,7 +35,11 @@ public class FileSystemTestResourceGenerator implements TestResourceFinderGenera
         if (resourceRoot.startsWith("file:///")) {
             return Arrays.stream(resources).map(resourceRoot::concat).collect(Collectors.toList());
         }
-        String root = !resourceRoot.endsWith("/") ? "**/" + resourceRoot + "/" : "**/" + resourceRoot;
+        String prefix = "**/";
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            prefix = "**";
+        }
+        String root = prefix + resourceRoot + (resourceRoot.endsWith("/") ? "" : "/");
         return Arrays.stream(resources).map(root::concat).collect(Collectors.toList());
     }
     @Override
@@ -46,7 +50,6 @@ public class FileSystemTestResourceGenerator implements TestResourceFinderGenera
         // Find the files we will be testing
         PathMatcher pathMatcher = new GlobPathMatcher(getGlobResourcePaths(includes),
                 getGlobResourcePaths(excludes));
-        TestResourceFinder finder = new FileSystemTestResourceFinder(pathMatcher);
-        return finder;
+        return new FileSystemTestResourceFinder(pathMatcher);
     }
 }

--- a/src/main/java/com/pdsl/specifications/GlobPathMatcher.java
+++ b/src/main/java/com/pdsl/specifications/GlobPathMatcher.java
@@ -7,23 +7,27 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class GlobPathMatcher implements PathMatcher {
 
-    private static final String GLOB = "glob:";
+    private static final String GLOB_PREFIX = "glob:";
     private final List<PathMatcher> includes;
     private final Optional<List<PathMatcher>> excludes;
 
+    private static String normalizeExpression(String expression) {
+        String normalized = expression;
+        return String.format("%s%s", GLOB_PREFIX, normalized);
+    }
+
     private static PathMatcher getMatcher(String expression) {
-        return FileSystems.getDefault().getPathMatcher(
-                expression.startsWith(GLOB) ? expression : String.format("%s%s", GLOB, expression));
+        return FileSystems.getDefault()
+                .getPathMatcher(expression.startsWith(GLOB_PREFIX) ? expression : GLOB_PREFIX + expression);
     }
 
     private static List<PathMatcher> getMatcher(List<String> expressions) {
         return expressions.stream()
                 .map(GlobPathMatcher::getMatcher)
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
     }
 
     public GlobPathMatcher(String includes, String excludes) {
@@ -68,11 +72,10 @@ public class GlobPathMatcher implements PathMatcher {
 
     @Override
     public boolean matches(Path path) {
-        if (excludes.isPresent()) {
-            return includes.stream().anyMatch(matcher -> matcher.matches(path))
-                    && excludes.get().stream().noneMatch(matcher -> matcher.matches(path));
-        } else {
-            return includes.stream().anyMatch(matcher -> matcher.matches(path));
-        }
+        Path normalizedPath = (path.isAbsolute() ? path : path.toAbsolutePath()).normalize();
+        return excludes.map(pathMatchers -> includes.stream().anyMatch(matcher -> matcher.matches(normalizedPath))
+                && pathMatchers.stream().noneMatch(matcher -> matcher.matches(normalizedPath)))
+                .orElseGet(() -> includes.stream().anyMatch(matcher -> matcher.matches(normalizedPath)));
     }
+
 }

--- a/src/main/java/org/junit/jupiter/engine/descriptor/PdslConfigParameter.java
+++ b/src/main/java/org/junit/jupiter/engine/descriptor/PdslConfigParameter.java
@@ -355,7 +355,7 @@ public class PdslConfigParameter {
                                     new String[] {param.getTagExpression()},
                                     param.getIncludesResources(),
                                     param.getExcludesResources(),
-                                    i.interpreterObj().getStartRule(),
+                                    i.interpreterObj().getStartRule().orElse(param.getStartRule().orElse(PdslTestParams.DEFAULT_ALL_RULE)),
                                     param.getRecognizerRule().isPresent() ? param.getRecognizerRule().get() : config.getRecognizerRule()
                             )
                     ).toList().toArray(new InterpreterParam[]{});
@@ -368,7 +368,7 @@ public class PdslConfigParameter {
                         new String[] {param.getTagExpression()},
                         param.getIncludesResources(),
                         param.getExcludesResources(),
-                        param.getStartRule(),
+                        param.getStartRule().orElse(PdslTestParams.DEFAULT_ALL_RULE),
                         param.getRecognizerRule().isPresent() ? param.getRecognizerRule().get() : config.getRecognizerRule()
                 )
         };

--- a/src/main/java/org/junit/jupiter/engine/descriptor/PdslGeneralInvocationContextProvider.java
+++ b/src/main/java/org/junit/jupiter/engine/descriptor/PdslGeneralInvocationContextProvider.java
@@ -137,7 +137,7 @@ public abstract class PdslGeneralInvocationContextProvider implements Invocation
         if (pdslTestParameter.getRecognizedByLexer().isPresent() && pdslTestParameter.getRecognizedByParser().isPresent()) {
             return executorHelper.makeDefaultFilter(pdslTestParameter.getParser(), pdslTestParameter.getLexer(),
                     pdslTestParameter.getRecognizedByParser().get(), pdslTestParameter.getRecognizedByLexer().get(),
-                    pdslTestParameter.getStartRule(),
+                    pdslTestParameter.getStartRule().orElseThrow(()->new IllegalArgumentException("TODO")),
                     pdslTestParameter.getRecognizerRule().isPresent() ? pdslTestParameter.getRecognizerRule().get() : configParameter.getRecognizerRule()
                     );
         }
@@ -147,7 +147,7 @@ public abstract class PdslGeneralInvocationContextProvider implements Invocation
                 pdslTestParameter.getLexer(),
                 configParameter.getDslRecognizerParser().isPresent() ? configParameter.getDslRecognizerParser().get() : pdslTestParameter.getParser(),
                 configParameter.getDslRecognizerLexer().isPresent() ? configParameter.getDslRecognizerLexer().get() : pdslTestParameter.getLexer(),
-                pdslTestParameter.getStartRule(),
+                pdslTestParameter.getStartRule().orElseThrow(()->new IllegalArgumentException("TODO")),
                 pdslTestParameter.getRecognizerRule().isPresent() ? pdslTestParameter.getRecognizerRule().get() : configParameter.getRecognizerRule()
         );
         return phraseFilter;

--- a/src/main/java/org/junit/jupiter/engine/descriptor/PdslGeneralInvocationContextProvider.java
+++ b/src/main/java/org/junit/jupiter/engine/descriptor/PdslGeneralInvocationContextProvider.java
@@ -137,20 +137,35 @@ public abstract class PdslGeneralInvocationContextProvider implements Invocation
         if (pdslTestParameter.getRecognizedByLexer().isPresent() && pdslTestParameter.getRecognizedByParser().isPresent()) {
             return executorHelper.makeDefaultFilter(pdslTestParameter.getParser(), pdslTestParameter.getLexer(),
                     pdslTestParameter.getRecognizedByParser().get(), pdslTestParameter.getRecognizedByLexer().get(),
-                    pdslTestParameter.getStartRule().orElseThrow(()->new IllegalArgumentException("TODO")),
+                    getRequiredStartRule(pdslTestParameter),
                     pdslTestParameter.getRecognizerRule().isPresent() ? pdslTestParameter.getRecognizerRule().get() : configParameter.getRecognizerRule()
                     );
         }
         // Otherwise use the recognizer specified in the configuration. If none specified, the parser used by the
         // pdslTest will be used as the recognizer as well.
-        PolymorphicDslPhraseFilter phraseFilter = executorHelper.makeDefaultFilter(pdslTestParameter.getParser(),
+        return executorHelper.makeDefaultFilter(pdslTestParameter.getParser(),
                 pdslTestParameter.getLexer(),
                 configParameter.getDslRecognizerParser().isPresent() ? configParameter.getDslRecognizerParser().get() : pdslTestParameter.getParser(),
                 configParameter.getDslRecognizerLexer().isPresent() ? configParameter.getDslRecognizerLexer().get() : pdslTestParameter.getLexer(),
-                pdslTestParameter.getStartRule().orElseThrow(()->new IllegalArgumentException("TODO")),
+                getRequiredStartRule(pdslTestParameter),
                 pdslTestParameter.getRecognizerRule().isPresent() ? pdslTestParameter.getRecognizerRule().get() : configParameter.getRecognizerRule()
         );
-        return phraseFilter;
+    }
+
+    /**
+     * Validates and retrieves the start rule from the test parameter.
+     *
+     * @param pdslTestParameter the test parameter containing the start rule
+     * @return the start rule string
+     * @throws IllegalArgumentException if the start rule is not present
+     */
+    private String getRequiredStartRule(PdslTestParameter pdslTestParameter) {
+        return pdslTestParameter.getStartRule().orElseThrow(() ->
+                new IllegalArgumentException(
+                        "Start rule is required for creating the phrase filter. " +
+                                "Please provide a start rule using PdslTestParameter.Builder.withStartRule()"
+                )
+        );
     }
 
     /**

--- a/src/main/java/org/junit/jupiter/engine/descriptor/PdslTestParameter.java
+++ b/src/main/java/org/junit/jupiter/engine/descriptor/PdslTestParameter.java
@@ -92,8 +92,8 @@ public class PdslTestParameter {
         return excludesResources;
     }
 
-    public String getStartRule() {
-        return startRule;
+    public Optional<String> getStartRule() {
+        return Optional.ofNullable(startRule);
     }
 
     public Optional<String> getRecognizerRule() {

--- a/src/test/antlr4/com/pdsl/grammars/AllGrammarsTwoParser.g4
+++ b/src/test/antlr4/com/pdsl/grammars/AllGrammarsTwoParser.g4
@@ -1,0 +1,5 @@
+parser grammar AllGrammarsTwoParser;
+
+options {tokenVocab=AllGrammarsLexer; }
+
+customStartRule : ALL_INPUTS+;

--- a/src/test/java/com/pdsl/api/FrameworkSpecifications.java
+++ b/src/test/java/com/pdsl/api/FrameworkSpecifications.java
@@ -5,6 +5,7 @@ import com.pdsl.grammars.*;
 import com.pdsl.reports.TestRunResults;
 import com.pdsl.transformers.DefaultPolymorphicDslPhraseFilter;
 import com.pdsl.transformers.PolymorphicDslPhraseFilter;
+import org.junit.After;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -20,29 +21,29 @@ import static com.google.common.truth.Truth.assertThat;
 
 public class FrameworkSpecifications {
 
+    @After
+    public void cleanUp() {
+        System.setProperty("pdsl.filterDuplicates", "false");
+    }
+
     @Test
     public void gherkinPdslTestFramework_meetsTestSpecifications() throws IOException, URISyntaxException {
 
         final URI testResources = getClass().getClassLoader()
                 .getResource("framework_specifications/features/PdslTestFramework.feature").toURI();
         // Arrange
-        Set<URI> dslFiles = new HashSet<>();
-        Path tmpDir = Files.createTempDirectory(String.format("pdsl_temp_test-%s", UUID.randomUUID()));
-        dslFiles.add(testResources);
+        Set<URI> dslFiles = Set.of(testResources);
         PolymorphicDslPhraseFilter phraseFilter = new DefaultPolymorphicDslPhraseFilter(
                 PdslFrameworkSpecificationParser.class,
                 PdslFrameworkSpecificationLexer.class
         );
-        try {
-            // Enable filtering
-            System.setProperty("pdsl.filterDuplicates", "true");
-            GherkinTestExecutor gherkinTestExecutor = new GherkinTestExecutor(phraseFilter);
-            // Act
-            TestRunResults results = gherkinTestExecutor.processFilesAndRunTests(dslFiles, new PdslFrameworkSpecificationImpl());
-            assertThat(results.failingTestTotal()).isEqualTo(0);
-            assertThat(results.totalFilteredDuplicateTests()).isEqualTo(1);
-        } finally {
-            System.setProperty("pdsl.filterDuplicates", "false");
-        }
+        // Enable filtering
+        System.setProperty("pdsl.filterDuplicates", "true");
+        GherkinTestExecutor gherkinTestExecutor = new GherkinTestExecutor(phraseFilter);
+        // Act
+        TestRunResults results = gherkinTestExecutor.processFilesAndRunTests(dslFiles, new PdslFrameworkSpecificationImpl());
+        assertThat(results.failingTestTotal()).isEqualTo(0);
+        assertThat(results.totalFilteredDuplicateTests()).isEqualTo(1);
+
     }
 }

--- a/src/test/java/com/pdsl/component/AsciiDoctorTraceableReport.java
+++ b/src/test/java/com/pdsl/component/AsciiDoctorTraceableReport.java
@@ -45,7 +45,7 @@ public class AsciiDoctorTraceableReport {
             .sourceHighlighter("rouge")
     ).safe(SafeMode.UNSAFE);
 
-    private static enum Context {
+    private enum Context {
         UNIT,
         COMPONENT,
         API,

--- a/src/test/java/com/pdsl/component/TestResourceFinderComponent.java
+++ b/src/test/java/com/pdsl/component/TestResourceFinderComponent.java
@@ -2,6 +2,7 @@ package com.pdsl.component;
 
 import com.pdsl.specifications.FileSystemTestResourceFinder;
 import com.pdsl.specifications.GlobPathMatcher;
+import org.codehaus.plexus.util.FileUtils;
 import org.junit.Test;
 
 import java.net.URI;
@@ -11,11 +12,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.common.io.Resources.getResource;
 import static com.google.common.truth.Truth.assertThat;
 
 public class TestResourceFinderComponent {
 
-    private final Path resourcesDirectory = Path.of(getClass().getClassLoader().getResource("test_resource_finder").getPath());
+    private final Path resourcesDirectory = FileUtils.getFile(getResource("test_resource_finder").getPath()).toPath();
 
     @Test
     public void resourceFinder_canRecursivelyMatchFiles() {

--- a/src/test/java/com/pdsl/gherkin/models/ExampleTokens.java
+++ b/src/test/java/com/pdsl/gherkin/models/ExampleTokens.java
@@ -65,18 +65,22 @@ public class ExampleTokens {
         GherkinStep step = featureOptional.get().getOptionalGherkinScenarios().get().get(0).getStepsList().get().get(1);
         GherkinExamplesTable examplesTable = featureOptional.get().getOptionalGherkinScenarios().get().get(0).getExamples().get().get(0);
         List<Map<String, String>> rows = examplesTable.getRows();
-        GherkinString stepDataTableCell = step.getDataTable().get().get(0).get(0);
+        assertThat(rows).hasSize(2);
         // Assert
+        GherkinString stepDataTableCell = step.getDataTable().get().get(0).get(0);
         // First examples row substitutions
         assertThat(stepDataTableCell.hasSubstitutions()).isTrue();
         Map<String, String> firstRowSubs = rows.get(0);
         assertThat(step.getStepContent().getStringWithSubstitutions(firstRowSubs))
                 .isEqualTo("    Given the quatre:\n");
-        assertThat("cinq").isEqualTo(stepDataTableCell.getStringWithSubstitutions(firstRowSubs));
+        assertThat(stepDataTableCell.getStringWithSubstitutions(firstRowSubs))
+                .isEqualTo("cinq");
 
         // Second examples row substitutions
         Map<String, String> secondRowSubs = rows.get(1);
-        assertThat("    Given the quatro:\n").isEqualTo(step.getStepContent().getStringWithSubstitutions(secondRowSubs));
-        assertThat("cinco").isEqualTo(stepDataTableCell.getStringWithSubstitutions(secondRowSubs));
+        assertThat(step.getStepContent().getStringWithSubstitutions(secondRowSubs))
+                .isEqualTo("    Given the quatro:\n");
+        assertThat(stepDataTableCell.getStringWithSubstitutions(secondRowSubs))
+                .isEqualTo("cinco");
     }
 }

--- a/src/test/java/com/pdsl/uat/java/JavaTestRunner.java
+++ b/src/test/java/com/pdsl/uat/java/JavaTestRunner.java
@@ -1,6 +1,6 @@
 package com.pdsl.uat.java;
 
-import com.pdsl.grammars.PdslHelper;
+import com.pdsl.grammars.*;
 import com.pdsl.runners.PdslGherkinApplication;
 import com.pdsl.runners.PdslTest;
 import com.pdsl.runners.junit.PdslGherkinJUnit4Runner;
@@ -10,9 +10,7 @@ import org.antlr.v4.runtime.tree.ParseTreeListener;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
-import com.pdsl.grammars.PdslJavaTestRunnerParserListener;
-import com.pdsl.grammars.JavaTestRunnerLexer;
-import com.pdsl.grammars.PdslJavaTestRunnerParser;
+
 import javax.inject.Provider;
 import java.util.HashMap;
 import java.util.Map;
@@ -23,6 +21,8 @@ import static com.google.common.truth.Truth.assertThat;
 @RunWith(PdslGherkinJUnit4Runner.class)
 @PdslGherkinApplication(
         resourceRoot = "src/test/resources/framework_specifications/features/java",
+        dslRecognizerParser = AllGrammarsParser.class,
+        dslRecognizerLexer = AllGrammarsLexer.class,
         recognizerRule = "polymorphicDslAllRules"
 )
 public class JavaTestRunner {
@@ -30,7 +30,7 @@ public class JavaTestRunner {
     @PdslTest(
             parser = PdslJavaTestRunnerParser.class,
             lexer = JavaTestRunnerLexer.class,
-            includesResources = "PdslJavaTestRunner.feature",
+            includesResources = "JavaTestRunner.feature",
             listener = JavaTestRunner.PdslJavaTestRunnerProvider.class
     )
     /*

--- a/src/test/java/com/pdsl/uat/java/jupiter/InterpreterObjStartRuleTest.java
+++ b/src/test/java/com/pdsl/uat/java/jupiter/InterpreterObjStartRuleTest.java
@@ -86,7 +86,7 @@ public class InterpreterObjStartRuleTest {
     @Test
     public void testConstructorWithListenerAndStartRule() {
         ParseTreeListener listener = new AllGrammarsParserBaseListener();
-        InterpreterObj interpreterObj = new InterpreterObj(listener, "listenerConstructorRule");
+        InterpreterObj interpreterObj = InterpreterObj.ofListener(()-> listener, "listenerConstructorRule");
 
         Assertions.assertTrue(interpreterObj.getStartRule().isPresent());
         Assertions.assertEquals("listenerConstructorRule", interpreterObj.getStartRule().get());

--- a/src/test/java/com/pdsl/uat/java/jupiter/InterpreterObjStartRuleTest.java
+++ b/src/test/java/com/pdsl/uat/java/jupiter/InterpreterObjStartRuleTest.java
@@ -2,7 +2,10 @@ package com.pdsl.uat.java.jupiter;
 
 import com.pdsl.executors.InterpreterObj;
 import com.pdsl.grammars.*;
+import org.antlr.v4.runtime.tree.ParseTreeListener;
+import org.antlr.v4.runtime.tree.ParseTreeVisitor;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -14,6 +17,108 @@ import java.util.List;
 import java.util.stream.Stream;
 
 public class InterpreterObjStartRuleTest {
+
+    @Test
+    public void testVisitorWithCustomStartRule() {
+        InterpreterObj interpreterObj = InterpreterObj.ofVisitor(
+            AllGrammarsTwoParserBaseVisitor::new,
+            "customStartRule"
+        );
+
+        Assertions.assertTrue(interpreterObj.getStartRule().isPresent());
+        Assertions.assertEquals("customStartRule", interpreterObj.getStartRule().get());
+        Assertions.assertTrue(interpreterObj.getParseTreeVisitor().isPresent());
+        Assertions.assertFalse(interpreterObj.getParseTreeListener().isPresent());
+    }
+
+    @Test
+    public void testVisitorWithoutStartRule() {
+        InterpreterObj interpreterObj = InterpreterObj.ofVisitor(
+            AllGrammarsTwoParserBaseVisitor::new
+        );
+
+        Assertions.assertFalse(interpreterObj.getStartRule().isPresent());
+        Assertions.assertTrue(interpreterObj.getParseTreeVisitor().isPresent());
+    }
+
+    @Test
+    public void testListenerWithCustomStartRule() {
+        InterpreterObj interpreterObj = InterpreterObj.ofListener(
+            AllGrammarsParserBaseListener::new,
+            "customListenerRule"
+        );
+
+        Assertions.assertTrue(interpreterObj.getStartRule().isPresent());
+        Assertions.assertEquals("customListenerRule", interpreterObj.getStartRule().get());
+        Assertions.assertTrue(interpreterObj.getParseTreeListener().isPresent());
+        Assertions.assertFalse(interpreterObj.getParseTreeVisitor().isPresent());
+    }
+
+    @Test
+    public void testListenerWithoutStartRule() {
+        InterpreterObj interpreterObj = InterpreterObj.ofListener(
+            AllGrammarsParserBaseListener::new
+        );
+
+        Assertions.assertFalse(interpreterObj.getStartRule().isPresent());
+        Assertions.assertTrue(interpreterObj.getParseTreeListener().isPresent());
+    }
+
+    @Test
+    public void testListenerWithNullStartRule() {
+        InterpreterObj interpreterObj = InterpreterObj.ofListener(
+            AllGrammarsParserBaseListener::new,
+            null
+        );
+
+        Assertions.assertFalse(interpreterObj.getStartRule().isPresent());
+    }
+
+    @Test
+    public void testConstructorWithVisitorAndStartRule() {
+        ParseTreeVisitor<?> visitor = new AllGrammarsTwoParserBaseVisitor<>();
+        InterpreterObj interpreterObj = new InterpreterObj(visitor, "directConstructorRule");
+
+        Assertions.assertTrue(interpreterObj.getStartRule().isPresent());
+        Assertions.assertEquals("directConstructorRule", interpreterObj.getStartRule().get());
+    }
+
+    @Test
+    public void testConstructorWithListenerAndStartRule() {
+        ParseTreeListener listener = new AllGrammarsParserBaseListener();
+        InterpreterObj interpreterObj = new InterpreterObj(listener, "listenerConstructorRule");
+
+        Assertions.assertTrue(interpreterObj.getStartRule().isPresent());
+        Assertions.assertEquals("listenerConstructorRule", interpreterObj.getStartRule().get());
+    }
+
+    @Test
+    public void testSupplierReturnsNewInstancesForVisitor() {
+        InterpreterObj interpreterObj = InterpreterObj.ofVisitor(
+            AllGrammarsTwoParserBaseVisitor::new,
+            "testRule"
+        );
+
+        ParseTreeVisitor<?> visitor1 = interpreterObj.getParseTreeVisitor().get();
+        ParseTreeVisitor<?> visitor2 = interpreterObj.getParseTreeVisitor().get();
+
+        Assertions.assertNotSame(visitor1, visitor2);
+        Assertions.assertEquals("testRule", interpreterObj.getStartRule().get());
+    }
+
+    @Test
+    public void testSupplierReturnsNewInstancesForListener() {
+        InterpreterObj interpreterObj = InterpreterObj.ofListener(
+            AllGrammarsParserBaseListener::new,
+            "testListenerRule"
+        );
+
+        ParseTreeListener listener1 = interpreterObj.getParseTreeListener().get();
+        ParseTreeListener listener2 = interpreterObj.getParseTreeListener().get();
+
+        Assertions.assertNotSame(listener1, listener2);
+        Assertions.assertEquals("testListenerRule", interpreterObj.getStartRule().get());
+    }
 
     @TestTemplate
     @ExtendWith(PdslExtension.class)

--- a/src/test/java/com/pdsl/uat/java/jupiter/InterpreterObjStartRuleTest.java
+++ b/src/test/java/com/pdsl/uat/java/jupiter/InterpreterObjStartRuleTest.java
@@ -1,0 +1,52 @@
+package com.pdsl.uat.java.jupiter;
+
+import com.pdsl.executors.InterpreterObj;
+import com.pdsl.grammars.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.engine.descriptor.*;
+
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class InterpreterObjStartRuleTest {
+
+    @TestTemplate
+    @ExtendWith(PdslExtension.class)
+    public void pdslGherkinTestFrameworkResources(PdslExecutable executable) {
+        executable.execute();
+    }
+
+    private static class PdslExtension extends PdslSharedInvocationContextProvider {
+
+        @Override
+        public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+            return getInvocationContext(PdslConfigParameter.createGherkinPdslConfig(
+                            List.of(
+                                    new PdslTestParameter.Builder(
+                                            List.of(
+                                                    new Interpreter(AllGrammarsLexer.class, AllGrammarsParser.class,
+                                                            InterpreterObj.ofListener(AllGrammarsParserBaseListener::new, "polymorphicDslAllRules")),
+                                                    new Interpreter(AllGrammarsLexer.class, AllGrammarsTwoParser.class,
+                                                            InterpreterObj.ofVisitor(AllGrammarsTwoParserBaseVisitor::new))
+                                            )
+                                    )
+                                            .withStartRule("customStartRule")
+                                            .build()
+                            )
+                    )
+                    .withDslRecognizerLexer(AllGrammarsLexer.class)
+                    .withDslRecognizerParser(AllGrammarsParser.class)
+                    .withApplicationName("Polymorphic DSL Framework")
+                    .withContext("User Acceptance Test")
+                    .withResourceRoot(Paths.get("src/test/resources/framework_specifications/features/interpreter/").toUri())
+                    .withRecognizerRule("polymorphicDslAllRules")
+                    .build())
+                    .stream();
+        }
+    }
+}

--- a/src/test/java/com/pdsl/uat/java/jupiter/Junit5MultiInterpreterTest.java
+++ b/src/test/java/com/pdsl/uat/java/jupiter/Junit5MultiInterpreterTest.java
@@ -28,32 +28,29 @@ import com.pdsl.grammars.MultiInterpreterRecognizerLexer;
 import com.pdsl.grammars.MultiInterpreterRecognizerParser;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor;
-import org.antlr.v4.runtime.tree.ParseTreeListener;
 import org.antlr.v4.runtime.tree.ParseTreeVisitor;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.engine.descriptor.Interpreter;
 import org.junit.jupiter.engine.descriptor.PdslConfigParameter;
 import org.junit.jupiter.engine.descriptor.PdslExecutable;
-import org.junit.jupiter.engine.descriptor.PdslGherkinInvocationContextProvider;
 import org.junit.jupiter.engine.descriptor.PdslSharedInvocationContextProvider;
 import org.junit.jupiter.engine.descriptor.PdslTestParameter;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class Junit5MultiInterpreterTest {
 
   private int totalRunTests = 0;
 
   private static final Context context = new Context();
 
-  // @RegisterExtension private final PdslExtension pdslExtension = new PdslExtension(context);
   @TestTemplate
   @ExtendWith(PdslExtension.class)
   public void pdslGherkinTestFrameworkResources(PdslExecutable executable) {
@@ -62,9 +59,6 @@ public class Junit5MultiInterpreterTest {
     Assertions.assertEquals(2, context.sharedSentenceCalls);
     Assertions.assertTrue(context.independentSentenceCalls);
   }
-
-  private static final Supplier<ParseTreeListener> parseTreeListenerSupplier = () -> new AllGrammarsParserBaseListener();
-
 
   private static class PdslExtension extends PdslSharedInvocationContextProvider {
 
@@ -91,8 +85,7 @@ public class Junit5MultiInterpreterTest {
                           List.of(
                               new Interpreter(MultiInterpreterLexer.class, MultiInterpreterParser.class,
                                   new InterpreterObj(parserOneVisitor, "parserOneAllRules")),
-                              new Interpreter(MultiInterpreter2Lexer.class,
-                                  MultiInterpreter2Parser.class,
+                              new Interpreter(MultiInterpreter2Lexer.class, MultiInterpreter2Parser.class,
                                   new InterpreterObj(parserTwoVisitor, "parserTwoAllRules")))
                       )
                           .withIncludedResources(new String[]{"MultiInterpreter.feature"})
@@ -107,7 +100,6 @@ public class Junit5MultiInterpreterTest {
               .withResourceRoot(
                   Paths.get("src/test/resources/framework_specifications/features/interpreter/")
                       .toUri())
-              // .withRecognizerRule("polymorphicDslAllRules")
               .build())
           .stream();
     }

--- a/src/test/java/com/pdsl/uat/java/jupiter/JupiterTagFilteringTest.java
+++ b/src/test/java/com/pdsl/uat/java/jupiter/JupiterTagFilteringTest.java
@@ -26,7 +26,7 @@ public class JupiterTagFilteringTest {
         assert(totalRunTests == 1);
     }
 
-    private static final Supplier<ParseTreeListener> parseTreeListenerSupplier = () -> new AllGrammarsParserBaseListener();
+    private static final Supplier<ParseTreeListener> parseTreeListenerSupplier = AllGrammarsParserBaseListener::new;
 
     private static class PdslExtension extends PdslGherkinInvocationContextProvider {
 

--- a/src/test/java/com/pdsl/uat/java/jupiter/PdslTestTemplate.java
+++ b/src/test/java/com/pdsl/uat/java/jupiter/PdslTestTemplate.java
@@ -36,11 +36,12 @@ public class PdslTestTemplate {
         executable.execute();
     }
 
-    private static final Supplier<ParseTreeListener> parseTreeListenerSupplier = () -> new AllGrammarsParserBaseListener();
+    private static final Supplier<ParseTreeListener> parseTreeListenerSupplier = AllGrammarsParserBaseListener::new;
 
     private static class PdslExtension extends PdslGeneralInvocationContextProvider {
         private final Supplier<TestCaseFactory> testCaseFactorySupplier = () -> new PreorderTestCaseFactory.DefaultProvider().get();
-        private final Supplier<TestSpecificationFactoryGenerator> testSpecificationFactoryGeneratorSupplier = () -> new LineDelimitedTestSpecificationFactory.Generator();
+        private final Supplier<TestSpecificationFactoryGenerator> testSpecificationFactoryGeneratorSupplier
+                = LineDelimitedTestSpecificationFactory.Generator::new;
 
         @Override
         public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
@@ -69,7 +70,7 @@ public class PdslTestTemplate {
                     List.of(
                             new PdslTestParameter.Builder(
                                     PdslJavaTestRunnerLexer.class, PdslJavaTestRunnerParser.class, () -> INSTANCE)
-                                    .withIncludedResources(new String[] {"JavaTestRunner.feature", "JavaDeleteMe.feature"})
+                                    .withIncludedResources(new String[] {"JavaTestRunner.feature"})
                                     .build()
                             )
                     )
@@ -83,7 +84,7 @@ public class PdslTestTemplate {
     }
 
     static class JupiterFrameworkVisitor extends AbstractParseTreeVisitor<Void>  implements PdslJavaTestRunnerParserVisitor<Void> {
-        private static final Supplier<ParseTreeVisitor<?>> VISITOR_SUPPLIER = () -> new AllGrammarsParserBaseVisitor<>();
+        private static final Supplier<ParseTreeVisitor<?>> VISITOR_SUPPLIER = AllGrammarsParserBaseVisitor::new;
         private PdslTestParameter.Builder pdslTestBuilder;
         private PdslConfigParameter.Builder configBuilder;
         private final Set<ConfigParam> configParameters = new HashSet<>(); //We need to delay initialization of the configBuilder
@@ -98,30 +99,22 @@ public class PdslTestTemplate {
             GOOD_RECOGNIZER;
 
             private static ConfigParam create(String str) {
-                switch (str) {
-                    case "resourceRoot":
-                        return RESOURCE_ROOT;
-                    case "testRunExecutor":
-                        return TEST_RUN_EXECUTOR;
-                    case "resourceFinder":
-                        return RESOURCE_FINDER;
-                    case "dslRecognizerLexer":
-                    case "dslRecognizerParser":
-                        return GOOD_RECOGNIZER;
-                    case "recognizerRule":
-                        return RECOGNIZER_RULE;
-
-                    default:
-                        throw new IllegalArgumentException("Do not know of a value for " + str);
-                }
+                return switch (str) {
+                    case "resourceRoot" -> RESOURCE_ROOT;
+                    case "testRunExecutor" -> TEST_RUN_EXECUTOR;
+                    case "resourceFinder" -> RESOURCE_FINDER;
+                    case "dslRecognizerLexer", "dslRecognizerParser" -> GOOD_RECOGNIZER;
+                    case "recognizerRule" -> RECOGNIZER_RULE;
+                    default -> throw new IllegalArgumentException("Do not know of a value for " + str);
+                };
             }
         }
         public Void visitGivenPdslTest(PdslJavaTestRunnerParser.GivenPdslTestContext ctx) {
             configParameters.clear();
             configBuilder = PdslConfigParameter.createGherkinPdslConfig(
                             List.of(
-                                    new PdslTestParameter.Builder(
-                                            PdslJavaTestRunnerLexer.class, PdslJavaTestRunnerParser.class, () -> new AllGrammarsParserBaseVisitor<>())
+                                    new PdslTestParameter.Builder(PdslJavaTestRunnerLexer.class,
+                                            PdslJavaTestRunnerParser.class, AllGrammarsParserBaseVisitor::new)
                                             .withIncludedResources(new String[] {"JavaTestRunner.feature"})
                                             .build()
                             )

--- a/src/test/java/com/pdsl/uat/java/jupiter/SharedTestCaseTest.java
+++ b/src/test/java/com/pdsl/uat/java/jupiter/SharedTestCaseTest.java
@@ -12,9 +12,11 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.engine.descriptor.*;
 
 import java.nio.file.Paths;
-import java.sql.SQLOutput;
 import java.util.List;
 import java.util.stream.Stream;
+
+import static com.pdsl.interpreter.InterpreterOne.InterpreterOneListenerProvider;
+import static com.pdsl.interpreter.InterpreterTwo.InterpreterTwoListenerProvider;
 
 public class SharedTestCaseTest {
 
@@ -55,10 +57,9 @@ public class SharedTestCaseTest {
                                     new PdslTestParameter.Builder(
                                             List.of(
                                             new Interpreter(InterpreterOneLexer.class, InterpreterOneParser.class,
-                                                    new InterpreterObj(
-                                                            new InterpreterOne.InterpreterOneListenerProvider().get())),
+                                                    new InterpreterObj(new InterpreterOneListenerProvider().get())),
                                             new Interpreter(InterpreterTwoLexer.class, InterpreterTwoParser.class,
-                                                    new InterpreterObj(new InterpreterTwo.InterpreterTwoListenerProvider().get()))
+                                                    new InterpreterObj(new InterpreterTwoListenerProvider().get()))
                                             )
                                     )
                                             .withStartRule("polymorphicDslAllRules")
@@ -87,10 +88,9 @@ public class SharedTestCaseTest {
                             List.of(
                                     new PdslTestParameter.Builder(List.of(
                                             new Interpreter(InterpreterOneLexer.class, InterpreterOneParser.class,
-                                                    new InterpreterObj(
-                                                            new InterpreterOne.InterpreterOneListenerProvider().get())),
+                                                    new InterpreterObj(new InterpreterOneListenerProvider().get())),
                                             new Interpreter(InterpreterTwoLexer.class, InterpreterTwoParser.class,
-                                                    new InterpreterObj(new InterpreterTwo.InterpreterTwoListenerProvider().get()))
+                                                    new InterpreterObj(new InterpreterTwoListenerProvider().get()))
                                             )
                                     )
                                             .withStartRule("polymorphicDslAllRules")
@@ -118,8 +118,7 @@ public class SharedTestCaseTest {
                             List.of(
                                     new PdslTestParameter.Builder(List.of(
                                             new Interpreter(InterpreterOneLexer.class, InterpreterOneParser.class,
-                                                    new InterpreterObj(
-                                                            new InterpreterOne.InterpreterOneListenerProvider().get()))
+                                                    new InterpreterObj(new InterpreterOneListenerProvider().get()))
                                         )
                                     )
                                             .withStartRule("polymorphicDslAllRules")

--- a/src/test/java/com/pdsl/uat/java/sut/NoRecognizerRunner.java
+++ b/src/test/java/com/pdsl/uat/java/sut/NoRecognizerRunner.java
@@ -1,5 +1,6 @@
 package com.pdsl.uat.java.sut;
 
+import com.pdsl.grammars.*;
 import com.pdsl.runners.PdslConfiguration;
 import com.pdsl.runners.PdslTest;
 import com.pdsl.runners.junit.PdslJUnit4ConfigurableRunner;
@@ -8,14 +9,15 @@ import org.antlr.v4.runtime.tree.ParseTreeListener;
 import org.junit.runner.RunWith;
 
 import javax.inject.Provider;
-import com.pdsl.grammars.AlphaParser;
-import com.pdsl.grammars.AlphaLexer;
-import com.pdsl.grammars.AlphaParserBaseListener;
+
 @RunWith(PdslJUnit4ConfigurableRunner.class)
 @PdslConfiguration(
         specificationFactoryProvider = PdslConfigurableExecutorTest.SpecificationFactoryProvider.class,
         testCaseFactoryProvider = PdslConfigurableExecutorTest.TestCaseFactoryProvider.class,
-        resourceRoot = "src/test/resources/sentences/"
+        resourceRoot = "src/test/resources/sentences/",
+        dslRecognizerParser = AllGrammarsParser.class,
+        dslRecognizerLexer = AllGrammarsLexer.class,
+        recognizerRule = "polymorphicDslAllRules"
 )
 public class NoRecognizerRunner {
 

--- a/src/test/java/com/pdsl/uat/java/sut/TaggedScenarioRunner.java
+++ b/src/test/java/com/pdsl/uat/java/sut/TaggedScenarioRunner.java
@@ -14,7 +14,8 @@ import javax.inject.Provider;
 @PdslGherkinApplication(
         applicationName = "Polymorphic DSL Test Framework",
         context = "User Acceptance Testing",
-        resourceRoot = "src/test/resources/framework_specifications/features/java"
+        resourceRoot = "src/test/resources/framework_specifications/features/java",
+        recognizerRule = "polymorphicDslAllRules"
 )
 public class TaggedScenarioRunner {
     @PdslTest(

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.config.fixed.max-pool-size=5
+junit.jupiter.execution.parallel.config.fixed.parallelism=5


### PR DESCRIPTION
1. fix misprinting pom.xml
2. add in junit-platform.properties to tests
3. refactor InterpreterObj to use Optional for startRule and improve listener handling
4. implement unit test for verifying startRule