### PR TITLE
Fix issues in the processing multi-parameter tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.google.pdsl</groupId>
     <artifactId>pdsl</artifactId>
-    <version>1.12.0</version>
+    <version>1.12.1</version>
 
     <name>pdsl</name>
     <url>http://www.github.com/google/polymorphicDSL</url>

--- a/src/main/java/com/pdsl/runners/SharedTestSuiteVisitor.java
+++ b/src/main/java/com/pdsl/runners/SharedTestSuiteVisitor.java
@@ -45,11 +45,11 @@ public class SharedTestSuiteVisitor implements RecognizerParams.RecognizerParams
         Preconditions.checkNotNull(recognizerParams.interpreterConstraint(), "Visitor mode cannot be null");
         recognizerParams.pdslTestParams().forEach(interpreter -> Preconditions.checkNotNull(interpreter, "No null objects can be in the interpreter array!"));
         // Create a Shared Test Suite
-        List<List<TestCase>> testCasesPerInterpreters = new ArrayList<>();
-        List<InterpreterObj> interpreterObjs = new ArrayList<>();
+        List<SharedTestSuite.SharedTestCaseData> testCaseSharedDataList = new ArrayList<>();
 
         for (PdslTestParams params : recognizerParams.pdslTestParams()) {
-
+            List<List<TestCase>> testCasesPerInterpreters = new ArrayList<>();
+            List<InterpreterObj> interpreterObjs = new ArrayList<>();
             // Get the tests written in a DSL
             Set<URI> testResources;
             try {
@@ -79,12 +79,13 @@ public class SharedTestSuiteVisitor implements RecognizerParams.RecognizerParams
                 testCasesPerInterpreters.add(testCasesForSingleInterpreter);
                 interpreterObjs.add(parser.interpreterProvider().get());
             }
+            // Check for duplicate phrases for each interpreter in a case 'NO_DUPLICATES_PHRASES' interpreter constraint
+            if (recognizerParams.interpreterConstraint() == InterpreterConstraint.NO_DUPLICATES_PHRASES) {
+                checkForDuplicateTestCases(testCasesPerInterpreters);
+            }
+            testCaseSharedDataList.add(new SharedTestSuite.SharedTestCaseData(testCasesPerInterpreters, interpreterObjs));
         }
-        // Check for duplicate phrases for each interpreter in a case 'NO_DUPLICATES_PHRASES' interpreter constraint
-        if (recognizerParams.interpreterConstraint() == InterpreterConstraint.NO_DUPLICATES_PHRASES) {
-            checkForDuplicateTestCases(testCasesPerInterpreters);
-        }
-        return SharedTestSuite.of(testCasesPerInterpreters, interpreterObjs);
+        return SharedTestSuite.of(testCaseSharedDataList);
 
     }
 

--- a/src/main/java/com/pdsl/testcases/SharedTestSuite.java
+++ b/src/main/java/com/pdsl/testcases/SharedTestSuite.java
@@ -2,9 +2,11 @@ package com.pdsl.testcases;
 
 import com.google.common.base.Preconditions;
 import com.pdsl.executors.InterpreterObj;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class SharedTestSuite {
 
@@ -15,45 +17,83 @@ public class SharedTestSuite {
   private List<SharedTestCase> sharedTestCaseList;
 
 
+  /**
+   * A record that encapsulates the data required to create a {@link SharedTestSuite}.
+   *
+   * <p>This record serves as a data transfer object (DTO) that groups together the test cases and their
+   * corresponding interpreters. It also performs crucial validation in its compact constructor to ensure
+   * the integrity of the test data before it is processed further.
+   *
+   * <p>The validation rules are as follows:
+   * <ul>
+   *   <li>The number of inner lists in {@code testCaseList} must be equal to the number of interpreters
+   *       in {@code interpreterObj}. This ensures that each interpreter has a corresponding list of test cases.
+   *   <li>All inner lists in {@code testCaseList} must have the same size. This is necessary because the
+   *       framework collates the test cases by index across the different interpreter-specific lists.
+   * </ul>
+   *
+   * @param testCaseList A list of lists of {@link TestCase}s. Each inner list corresponds to a specific
+   *                     interpreter and contains the test cases for that interpreter.
+   * @param interpreterObj A list of {@link InterpreterObj}s that will be used to execute the test cases.
+   */
+  public record SharedTestCaseData(List<List<TestCase>> testCaseList, List<InterpreterObj> interpreterObj) {
+
+      public SharedTestCaseData {
+          /*
+          One test case per interpreter
+           */
+          int interpreterSize = interpreterObj.size();
+          /*
+          every interpreter should have its own test suite
+           */
+          Preconditions.checkArgument(testCaseList.size() == interpreterSize);
+          /*
+          every test suite should have the same number of test cases
+          * */
+          testCaseList.forEach(
+                  item -> Preconditions.checkArgument(item.size() == testCaseList.get(0).size()));
+      }
+
+  }
+
   private SharedTestSuite(List<SharedTestCase> sharedTestCasesList) {
     this.sharedTestCaseList = sharedTestCasesList;
   }
 
-  public static SharedTestSuite of(List<List<TestCase>> listOfTestCases,
-      List<InterpreterObj> interpreterObj) {
-    /* One test case per interpreter
-     */
-    int interpreterSize = interpreterObj.size();
-    /*
-    every interpreter should have its own test suite
-     */
-    Preconditions.checkArgument(listOfTestCases.size() == interpreterSize);
+  public static SharedTestSuite of(List<SharedTestCaseData> testCaseDataList) {
     /*
     every test suite should have the same number of test cases
     * */
-    listOfTestCases.forEach(
-        item -> Preconditions.checkArgument(item.size() == listOfTestCases.get(0).size()));
-    List<SharedTestCase> sharedTestCaseList = new ArrayList<>();
-    List<List<SharedTestCaseWithInterpreter>> listOfSharedTestCaseWithInterpreter = new ArrayList<>();
-    for (TestCase testCase : listOfTestCases.get(0)) {
-      listOfSharedTestCaseWithInterpreter.add(new ArrayList<>());
-    }
-    List<SharedTestCaseWithInterpreter> SharedTestCaseWithInterpreterList = new ArrayList<>();
-    for (int testCase = 0; testCase < listOfTestCases.get(0).size(); testCase++) { //3
-      for(int interpreterIndex =0; interpreterIndex<interpreterObj.size();interpreterIndex++) {
-        SharedTestCaseWithInterpreter sharedTestCaseWithInterpreter = new SharedTestCaseWithInterpreter(
-            listOfTestCases.get(interpreterIndex).get(testCase),interpreterObj.get(interpreterIndex));
-        SharedTestCaseWithInterpreterList.add(sharedTestCaseWithInterpreter);
-        listOfSharedTestCaseWithInterpreter.get(testCase).add(sharedTestCaseWithInterpreter);
+    return new SharedTestSuite(testCaseDataList.stream()
+            .map(testCaseData -> collateTestCasesWithInterpreters(testCaseData.testCaseList(), testCaseData.interpreterObj()))
+            .flatMap(Collection::stream)
+            .map(SharedTestCase::new)
+            .toList());
+  }
+
+  public static SharedTestSuite of(List<List<TestCase>> listOfTestCases,
+      List<InterpreterObj> interpreterObj) {
+    return of(List.of(new SharedTestCaseData(listOfTestCases, interpreterObj)));
+  }
+
+  private static @NonNull List<List<SharedTestCaseWithInterpreter>> collateTestCasesWithInterpreters(List<List<TestCase>> listOfTestCases,
+                                                                                                     List<InterpreterObj> interpreterObj) {
+    int numTestCases = listOfTestCases.get(0).size();
+    int numInterpreters = interpreterObj.size();
+    List<List<SharedTestCaseWithInterpreter>> result = new ArrayList<>(numTestCases);
+    for (int testCaseIndex = 0; testCaseIndex < numTestCases; testCaseIndex++) {
+      List<SharedTestCaseWithInterpreter> innerList = new ArrayList<>(numInterpreters);
+      for (int interpreterIndex = 0; interpreterIndex < numInterpreters; interpreterIndex++) {
+        innerList.add(new SharedTestCaseWithInterpreter(
+            listOfTestCases.get(interpreterIndex).get(testCaseIndex),
+            interpreterObj.get(interpreterIndex)));
       }
+      result.add(innerList);
     }
-    return new SharedTestSuite(
-        listOfSharedTestCaseWithInterpreter.stream().map(item -> new SharedTestCase(item)).collect(
-            Collectors.toUnmodifiableList()));
+    return result;
   }
 
   public static class SharedTestCaseWithInterpreter {
-
 
     private final InterpreterObj interpreterObj;
     private final TestCase testCase;
@@ -73,5 +113,3 @@ public class SharedTestSuite {
   }
 
 }
-
-

--- a/src/test/java/com/pdsl/testcases/SharedTestSuiteTest.java
+++ b/src/test/java/com/pdsl/testcases/SharedTestSuiteTest.java
@@ -1,0 +1,120 @@
+package com.pdsl.testcases;
+
+import com.pdsl.executors.InterpreterObj;
+import com.pdsl.specifications.FilteredPhrase;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.ErrorNode;
+import org.antlr.v4.runtime.tree.ParseTreeListener;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SharedTestSuiteTest {
+
+    private static final InterpreterObj DUMMY_INTERPRETER_1 = new InterpreterObj(new DummyListener());
+    private static final InterpreterObj DUMMY_INTERPRETER_2 = new InterpreterObj(new DummyListener());
+
+    private static final TestCase DUMMY_TEST_CASE_1 = new DummyTestCase("Test Case 1");
+    private static final TestCase DUMMY_TEST_CASE_2 = new DummyTestCase("Test Case 2");
+
+    @Test
+    void of_unevenLists_throwsException() {
+        List<List<TestCase>> testCases = List.of(
+                List.of(DUMMY_TEST_CASE_1),
+                List.of(DUMMY_TEST_CASE_1, DUMMY_TEST_CASE_2)
+        );
+        List<InterpreterObj> interpreters = List.of(DUMMY_INTERPRETER_1);
+        assertThrows(IllegalArgumentException.class, ()->SharedTestSuite.of(testCases, interpreters));
+    }
+
+    @Test
+    void of_validInput_createsSharedTestSuite() {
+        List<List<TestCase>> testCases = List.of(
+                List.of(DUMMY_TEST_CASE_1, DUMMY_TEST_CASE_2),
+                List.of(DUMMY_TEST_CASE_1, DUMMY_TEST_CASE_2)
+        );
+        List<InterpreterObj> interpreters = List.of(DUMMY_INTERPRETER_1, DUMMY_INTERPRETER_2);
+
+        SharedTestSuite sharedTestSuite = SharedTestSuite.of(testCases, interpreters);
+
+        assertThat(sharedTestSuite.getSharedTestCaseList()).hasSize(2);
+        SharedTestCase sharedTestCase1 = sharedTestSuite.getSharedTestCaseList().get(0);
+        assertThat(sharedTestCase1.getSharedTestCaseWithInterpreters()).hasSize(2);
+        assertThat(sharedTestCase1.getSharedTestCaseWithInterpreters().get(0).getTestCase()).isEqualTo(DUMMY_TEST_CASE_1);
+        assertThat(sharedTestCase1.getSharedTestCaseWithInterpreters().get(0).getInterpreterObj()).isEqualTo(DUMMY_INTERPRETER_1);
+
+        SharedTestCase sharedTestCase2 = sharedTestSuite.getSharedTestCaseList().get(1);
+        assertThat(sharedTestSuite.getSharedTestCaseList()).hasSize(2);
+        assertThat(sharedTestCase2.getSharedTestCaseWithInterpreters().get(0).getTestCase()).isEqualTo(DUMMY_TEST_CASE_2);
+        assertThat(sharedTestCase2.getSharedTestCaseWithInterpreters().get(0).getInterpreterObj()).isEqualTo(DUMMY_INTERPRETER_1);
+        assertThat(sharedTestCase2.getSharedTestCaseWithInterpreters().get(1).getTestCase()).isEqualTo(DUMMY_TEST_CASE_2);
+        assertThat(sharedTestCase2.getSharedTestCaseWithInterpreters().get(1).getInterpreterObj()).isEqualTo(DUMMY_INTERPRETER_2);
+    }
+
+    private record DummyTestCase(String name) implements TestCase {
+
+        @Override
+            public URI getOriginalSource() {
+                return null;
+            }
+
+            @Override
+            public List<String> getUnfilteredPhraseBody() {
+                return null;
+            }
+
+            @Override
+            public List<String> getContextFilteredPhraseBody() {
+                return null;
+            }
+
+            @Override
+            public String getTestTitle() {
+                return "";
+            }
+
+            @Override
+            public Iterator<TestSection> getContextFilteredTestSectionIterator() {
+                return null;
+            }
+
+            @Override
+            public List<FilteredPhrase> getFilteredPhrases() {
+                return List.of();
+            }
+
+            @Override
+            public Map<String, Object> getMetadata() {
+                return null;
+            }
+        }
+
+    private static class DummyListener implements ParseTreeListener {
+        @Override
+        public void visitTerminal(TerminalNode node) {
+
+        }
+
+        @Override
+        public void visitErrorNode(ErrorNode node) {
+
+        }
+
+        @Override
+        public void enterEveryRule(ParserRuleContext ctx) {
+
+        }
+
+        @Override
+        public void exitEveryRule(ParserRuleContext ctx) {
+
+        }
+    }
+}


### PR DESCRIPTION
1. bump library version to 1.12.1
2. fix the issue with the SharedTestSuite, when it uses multiple test parameters with different numbers of scenarios.
3. fix the `InterpreterConstraint` issue.